### PR TITLE
Add images download functionality.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -63,10 +63,18 @@ chrome.runtime.onMessage.addListener(function(request, sender) {
 
     itemUrls.forEach(function (url, index) {
       getUrlDocument(url).then(function (dom) {
+        //console.trace("Fetched:" + url);
         var downloadButton = dom.querySelector('.dev-page-download');
-
+        var titleLabel = dom.querySelector("h1 a").innerText;
+        var dateLabel = dom.querySelector("dd span").innerText;
+        
         if (downloadButton) {
-          gallery.downloadUrls.push(downloadButton.href);
+            var values = [downloadButton.href, url, titleLabel];
+            var date = new Date(dateLabel);
+            var ds = date.toISOString();
+            ds = ds.substring(0, ds.indexOf("T"))
+            values.push(ds)
+            gallery.downloadUrls.push(values);
         }
 
         if (index === itemUrls.length - 1) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,6 +17,7 @@
   ],
   "permissions": [
     "clipboardWrite",
+    "downloads",
     "http://*.deviantart.com/"
   ],
   "page_action": {

--- a/src/popup.html
+++ b/src/popup.html
@@ -19,7 +19,8 @@
             <i>Done.</i>
           {{/isCopied}}
 
-          <a href="#" data-id="{{id}}">Copy to clipboard</a>
+          <a class="copy" href="#" data-id="{{id}}">Copy to clipboard</a>
+          <a class="download" href="#" data-id="{{id}}">Copy and download ALL</a>
         {{/isComplete}}
 
         {{^isComplete}}

--- a/src/popup.js
+++ b/src/popup.js
@@ -31,11 +31,19 @@ var render = function () {
 queueNode.addEventListener('click', function (e) {
   var el = e.target,
       item;
-
+      
   if (el.dataset.id) {
     item = queue[el.dataset.id];
-    urls = item.downloadUrls.join('\n');
-    executeCopy(urls);
+    //console.trace(item);
+    var ccontent = ""
+    for (var i = 0; i < item.downloadUrls.length; i++)
+    {
+        if (e.target.class == "download") {
+            chrome.downloads.download({url: item.downloadUrls[i][0]});
+        }
+        ccontent += item.downloadUrls[i].join('\t') + '\n';
+    }
+    executeCopy(ccontent);
     item.isCopied = true;
 
     render();


### PR DESCRIPTION
I've tried your plugin today and it worked very well! But DA doesn't seem to allow me downloading these images outside the browser, and it's a tedious job to paste these URLs one by one in the address bar to download them. So I added a link to copy the links and download the images.

![dg-0 2-screenshot](https://cloud.githubusercontent.com/assets/11611687/18313936/8d03c806-7543-11e6-9aa6-b27a66dd747e.PNG)

At the same time, I added some other fields thay might be handy, and fields are delimited by tabs. Now the text put into clipboard is as follows

```
http://www.deviantart.com/download/621794024/samurai_ounce_by_tetesummers-daa77c8.jpg?token=6d14b24915369636305a8097b5acda59ac8f95bb&ts=1473255872  http://tetesummers.deviantart.com/art/Samurai-ounce-621794024   Samurai ounce   2001-07-14
http://www.deviantart.com/download/586623075/january_by_tetesummers-d9p9d9f.jpg?token=a79096f69e4d99012f62cef96d681bcf8f0ad7a3&ts=1473255873    http://tetesummers.deviantart.com/art/January-586623075 January 2001-01-24
...
```
